### PR TITLE
feat: Add DB_NAME configuration to README for PostgreSQL setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Create a `.env` file in the root directory:
 # 🗄️ Database Configuration
 ENV=dev
 DB=postgresql
+DB_NAME=your_db_name
 DB_USER=your_db_user
 DB_PASSWORD=your_db_password
 DB_HOST=localhost
@@ -300,6 +301,7 @@ pytest --cov=app --cov-report=html
 # Database Configuration (PostgreSQL)
 ENV=dev
 DB=postgresql
+DB_NAME=your_db_name
 DB_USER=your_username
 DB_PASSWORD=your_password
 DB_HOST=localhost


### PR DESCRIPTION
This pull request updates the `README.md` file to enhance clarity and completeness in the database configuration instructions. Specifically, it adds the `DB_NAME` variable to the `.env` file setup examples.

Database configuration updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161): Added the `DB_NAME` variable to the `.env` file setup example to specify the database name explicitly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R304)